### PR TITLE
Finish screenshots on test failure

### DIFF
--- a/elixir_sdet_exercise/.gitignore
+++ b/elixir_sdet_exercise/.gitignore
@@ -1,2 +1,3 @@
 _build/
 deps/
+screenshots/

--- a/elixir_sdet_exercise/config/config.exs
+++ b/elixir_sdet_exercise/config/config.exs
@@ -10,7 +10,6 @@ use Mix.Config
 
 config :hound,
   driver: "chrome_driver",
-  takes_screenshot: true,
   screenshot_dir: "screenshots"
 
 config :elixir_sdet_exercise, url: "https://www.facebook.com/r.php"

--- a/elixir_sdet_exercise/config/config.exs
+++ b/elixir_sdet_exercise/config/config.exs
@@ -8,7 +8,11 @@ use Mix.Config
 # if you want to provide default values for your application for
 # third-party users, it should be done in your "mix.exs" file.
 
-config :hound, driver: "chrome_driver"
+config :hound,
+  driver: "chrome_driver",
+  takes_screenshot: true,
+  screenshot_dir: "screenshots"
+
 config :elixir_sdet_exercise, url: "https://www.facebook.com/r.php"
 config :logger, level: :trace
 

--- a/elixir_sdet_exercise/lib/macros/screenshot_macro.ex
+++ b/elixir_sdet_exercise/lib/macros/screenshot_macro.ex
@@ -1,0 +1,27 @@
+defmodule ScreenshotMacro do
+  import Hound.Helpers.Screenshot
+
+  defmacro sstest(
+             test_name,
+             macro \\ quote do
+               _
+             end,
+             test_steps
+           ) do
+    quote do
+      test unquote(test_name), unquote(macro) do
+        try do
+          unquote(test_steps)
+        rescue
+          error ->
+            prefix = String.replace(unquote(test_name), ~r/\W+/, "-")
+            IO.inspect("Taking screenshot of failure")
+            # Took too long to figure out how to create a directory if it
+            # doesn't already exist, so screenshots will override each other
+            take_screenshot("screenshots/#{prefix}.png")
+            raise error
+        end
+      end
+    end
+  end
+end

--- a/elixir_sdet_exercise/lib/templates/facebook_case.ex
+++ b/elixir_sdet_exercise/lib/templates/facebook_case.ex
@@ -5,6 +5,7 @@ defmodule FacebookCase do
   # My attempt at "Page Object Pattern"
   using do
     quote do
+      import ScreenshotMacro
       @first_name_field {:name, "firstname"}
       @last_name_field {:name, "lastname"}
       @email_field {:name, "reg_email__"}

--- a/elixir_sdet_exercise/test/data/facebook_invalid_names.json
+++ b/elixir_sdet_exercise/test/data/facebook_invalid_names.json
@@ -1,6 +1,6 @@
-{
+[
   {"first": "First!", "last": "Last"},
   {"first": "First", "last": "Last!"},
   {"first": "@me", "last": "DontAtMeBro"},
   {"first": "DontAtMeBro", "last": "@me"}
-}
+]

--- a/elixir_sdet_exercise/test/facebook_screenshot_failure_test.exs
+++ b/elixir_sdet_exercise/test/facebook_screenshot_failure_test.exs
@@ -1,0 +1,48 @@
+defmodule FacebookScreenshotFailureTest do
+  import CustomSelectors
+  import DataStructs
+  import FileReader
+  import WaitFunctions
+
+  use Hound.Helpers
+  use ExUnit.Case, async: true
+  use FacebookCase, async: true
+
+  @long_names read_json_as_struct(
+                Path.join(__DIR__, "data/facebook_invalid_names.json"),
+                %DataStructs.Name{}
+              )
+
+  # These tests should generate 4 failure screenshots
+  for name <- @long_names do
+    @first_name name.first
+    @last_name name.last
+    @email_address "elixir_sdet_exercise@gmail.com"
+    @password_text "P@ssw0rd123"
+    @month_value "10"
+    @day_value "29"
+    @year_value "1929"
+
+    sstest "Invalid names #{String.slice(@first_name, 0..31)} #{String.slice(@last_name, 0..31)}" do
+      create_basic_account(
+        @first_name,
+        @last_name,
+        @email_address,
+        @password_text,
+        @month_value,
+        @day_value,
+        @year_value
+      )
+
+      # Use custom wait until error textbox appears
+      error_exists = wait_until_true(fn -> length(find_all_elements_by(@error_textbox)) > 0 end)
+      assert(error_exists)
+      error = find_element_by(@error_textbox)
+
+      assert(
+        visible_text(error) ==
+          "First or last names on Facebook can't have too many characters. Learn more about our name policies."
+      )
+    end
+  end
+end


### PR DESCRIPTION
This method uses defmacro to override test with our own testcase
function, sstest. Google was helpful to get me started but I had to
fix a lot of problems.

Last part of this I did not complete was generating the folder based on
the test name for each screenshot, and naming the image after the
current date time UTC. All of my attempts to do so failed. Remember to
ask interviewers how they would do this.